### PR TITLE
Fix 删除消息时若当前删除消息的上一条消息是时间信息时，会删除掉相同时间的时间信息(crash)

### DIFF
--- a/ChatDemo-UI2.0/ChatDemo-UI2.0/Class/Chat/ChatView/ChatViewController.m
+++ b/ChatDemo-UI2.0/ChatDemo-UI2.0/Class/Chat/ChatView/ChatViewController.m
@@ -935,8 +935,8 @@
 {
     if (_longPressIndexPath && _longPressIndexPath.row > 0) {
         MessageModel *model = [self.dataSource objectAtIndex:_longPressIndexPath.row];
-        NSMutableArray *messages = [NSMutableArray arrayWithObjects:model, nil];
         [_conversation removeMessage:model.message];
+        [self.dataSource removeObjectAtIndex:_longPressIndexPath.row];
         NSMutableArray *indexPaths = [NSMutableArray arrayWithObjects:_longPressIndexPath, nil];;
         if (_longPressIndexPath.row - 1 >= 0) {
             id nextMessage = nil;
@@ -945,11 +945,11 @@
                 nextMessage = [self.dataSource objectAtIndex:(_longPressIndexPath.row + 1)];
             }
             if ((!nextMessage || [nextMessage isKindOfClass:[NSString class]]) && [prevMessage isKindOfClass:[NSString class]]) {
-                [messages addObject:prevMessage];
-                [indexPaths addObject:[NSIndexPath indexPathForRow:(_longPressIndexPath.row - 1) inSection:0]];
+                NSInteger row = _longPressIndexPath.row - 1;
+                [self.dataSource removeObjectAtIndex:row];
+                [indexPaths addObject:[NSIndexPath indexPathForRow:row inSection:0]];
             }
         }
-        [self.dataSource removeObjectsInArray:messages];
         [self.tableView deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationFade];
     }
     


### PR DESCRIPTION
在当前删除消息的上一条消息是时间信息时，会同时删除掉多条相同时间的时间信息。从而造成dataSource删除的条数多于tableView delete掉的rows，引起App崩溃（"Invalid update: invalid number of rows in section 0.  The number of rows contained in an existing section after the update (3) must be equal to the number of rows contained in that section before the update (6), plus or minus the number of rows inserted or deleted from that section (0 inserted, 2 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out)."）。